### PR TITLE
Add AMSR2 product class and support .he5 file extension in XCAL

### DIFF
--- a/staremaster/products/__init__.py
+++ b/staremaster/products/__init__.py
@@ -9,3 +9,4 @@ from staremaster.products.satcorps import satCORPS
 from staremaster.products.modis_tilegrid import ModisTile
 from staremaster.products.goes_abi_fixed_grid import GOES_ABI_FIXED_GRID
 from staremaster.products.merra2 import MERRA2
+from staremaster.products.amsr2 import AMSR2

--- a/staremaster/products/amsr2.py
+++ b/staremaster/products/amsr2.py
@@ -1,0 +1,5 @@
+from staremaster.products.xcal import XCAL
+
+
+class AMSR2(XCAL):
+    scans = ['HDFEOS/SWATHS/AMSR2_L1R/Geolocation Fields/']

--- a/staremaster/products/xcal.py
+++ b/staremaster/products/xcal.py
@@ -24,7 +24,7 @@ class XCAL:
         
         if file_ext in ['.nc', '.nc4', '.netcdf']:
             return 'netcdf4'
-        elif file_ext in ['.h5', '.hdf5', '.hdf']:
+        elif file_ext in ['.he5', '.h5', '.hdf5', '.hdf']:
             return 'hdf5'
         else:
             # Try to detect by attempting to open with each format


### PR DESCRIPTION
Mike's modifications on:
- Add AMSR2 product class
- Support .he5 file extension in XCAL